### PR TITLE
Fix abcjs render target

### DIFF
--- a/components/MusicScore.js
+++ b/components/MusicScore.js
@@ -1,11 +1,16 @@
 import abcjs from 'abcjs'
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef } from 'react'
 
 const MusicScore = ({ code }) => {
+  const notationRef = useRef(null)
+
   useEffect(() => {
-    abcjs.renderAbc('musicNotation', code)
-  })
-  return <div id="musicNotation"></div>
+    if (notationRef.current) {
+      abcjs.renderAbc(notationRef.current, code)
+    }
+  }, [code])
+
+  return <div ref={notationRef}></div>
 }
 
 export default MusicScore


### PR DESCRIPTION
## Summary
- use ref to render abcjs so multiple scores don't conflict

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e70a5af34832e85b3ad46827d69cc