### PR TITLE
Add OGP previews for bare links in posts

### DIFF
--- a/components/Link.js
+++ b/components/Link.js
@@ -1,19 +1,38 @@
 /* eslint-disable jsx-a11y/anchor-has-content */
 import Link from 'next/link'
+import OgpCard from './OgpCard'
 
-const CustomLink = ({ href, ...rest }) => {
+const CustomLink = ({ href, children, ...rest }) => {
   const isInternalLink = href && href.startsWith('/')
   const isAnchorLink = href && href.startsWith('#')
+  const isEmbedLink =
+    href && !isInternalLink && !isAnchorLink && typeof children === 'string' && children === href
 
   if (isInternalLink) {
-    return <Link href={href} {...rest} />
+    return (
+      <Link href={href} {...rest}>
+        {children}
+      </Link>
+    )
   }
 
   if (isAnchorLink) {
-    return <a href={href} {...rest} />
+    return (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    )
   }
 
-  return <a target="_blank" rel="noopener noreferrer" href={href} {...rest} />
+  if (isEmbedLink) {
+    return <OgpCard url={href} />
+  }
+
+  return (
+    <a target="_blank" rel="noopener noreferrer" href={href} {...rest}>
+      {children}
+    </a>
+  )
 }
 
 export default CustomLink

--- a/components/OgpCard.js
+++ b/components/OgpCard.js
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react'
+import Image from './Image'
+
+const OgpCard = ({ url }) => {
+  const [data, setData] = useState(null)
+
+  useEffect(() => {
+    if (!url) return
+    const controller = new AbortController()
+    fetch(`https://api.microlink.io/?url=${encodeURIComponent(url)}`, {
+      signal: controller.signal,
+    })
+      .then((res) => res.json())
+      .then((json) => {
+        if (json.status === 'success') {
+          const { title, description, image, url: finalUrl } = json.data
+          setData({
+            title,
+            description,
+            image: image?.url,
+            url: finalUrl,
+          })
+        }
+      })
+      .catch(() => {})
+    return () => controller.abort()
+  }, [url])
+
+  if (!data) return null
+
+  return (
+    <a href={data.url} target="_blank" rel="noopener noreferrer" className="block my-4">
+      <div className="flex overflow-hidden rounded-md border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800">
+        {data.image && (
+          <div className="relative w-32 h-20 flex-shrink-0">
+            <Image src={data.image} alt="og image" fill className="object-cover" />
+          </div>
+        )}
+        <div className="p-2 text-sm">
+          <p className="font-semibold line-clamp-2">{data.title}</p>
+          {data.description && (
+            <p className="text-gray-500 dark:text-gray-400 line-clamp-2">{data.description}</p>
+          )}
+          <p className="text-xs text-gray-400 mt-1">{new URL(data.url).host}</p>
+        </div>
+      </div>
+    </a>
+  )
+}
+
+export default OgpCard

--- a/components/OgpCard.js
+++ b/components/OgpCard.js
@@ -29,19 +29,19 @@ const OgpCard = ({ url }) => {
   if (!data) return null
 
   return (
-    <a href={data.url} target="_blank" rel="noopener noreferrer" className="block my-4">
-      <div className="flex overflow-hidden rounded-md border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800">
+    <a href={data.url} target="_blank" rel="noopener noreferrer" className="my-4 block">
+      <div className="flex overflow-hidden rounded-md border border-gray-200 hover:bg-gray-100 dark:border-gray-700 dark:hover:bg-gray-800">
         {data.image && (
-          <div className="relative w-32 h-20 flex-shrink-0">
+          <div className="relative h-20 w-32 flex-shrink-0">
             <Image src={data.image} alt="og image" fill className="object-cover" />
           </div>
         )}
         <div className="p-2 text-sm">
-          <p className="font-semibold line-clamp-2">{data.title}</p>
+          <p className="line-clamp-2 font-semibold">{data.title}</p>
           {data.description && (
-            <p className="text-gray-500 dark:text-gray-400 line-clamp-2">{data.description}</p>
+            <p className="line-clamp-2 text-gray-500 dark:text-gray-400">{data.description}</p>
           )}
-          <p className="text-xs text-gray-400 mt-1">{new URL(data.url).host}</p>
+          <p className="mt-1 text-xs text-gray-400">{new URL(data.url).host}</p>
         </div>
       </div>
     </a>


### PR DESCRIPTION
## Summary
- render preview cards when MDX contains a bare URL
- introduce `OgpCard` component for fetching preview metadata

## Testing
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68503a3853f4832ebf3d7d9afecd256b