### PR TITLE
Add dynamic OG images

### DIFF
--- a/app/api/og/route.js
+++ b/app/api/og/route.js
@@ -1,0 +1,61 @@
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+
+const font = fetch(
+  new URL(
+    '../../../node_modules/@fontsource/inter/files/inter-all-700-normal.woff',
+    import.meta.url
+  )
+).then((res) => res.arrayBuffer())
+
+export async function GET(req) {
+  const { searchParams } = new URL(req.url)
+  const title = searchParams.get('title') || 'Bikpela Poteto Bilong Mi'
+  const fontData = await font
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '1200px',
+          height: '630px',
+          background: '#f8f8f8',
+          display: 'flex',
+          flexDirection: 'column',
+          padding: '60px',
+          justifyContent: 'space-between',
+          fontFamily: 'Inter',
+        }}
+      >
+        <div style={{ textAlign: 'center', fontSize: 40 }}>Bikpela Poteto Bilong Mi</div>
+        <div
+          style={{
+            flex: 1,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            textAlign: 'center',
+            fontSize: 80,
+            fontWeight: 700,
+            lineHeight: 1.2,
+          }}
+        >
+          {title}
+        </div>
+        <div style={{ alignSelf: 'flex-end', fontSize: 32 }}>sgktmk</div>
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 630,
+      fonts: [
+        {
+          name: 'Inter',
+          data: fontData,
+          weight: 700,
+          style: 'normal',
+        },
+      ],
+    }
+  )
+}

--- a/components/SEO.js
+++ b/components/SEO.js
@@ -84,12 +84,8 @@ export const BlogSEO = ({
   const router = useRouter()
   const publishedAt = new Date(date).toISOString()
   const modifiedAt = new Date(lastmod || date).toISOString()
-  let imagesArr =
-    images.length === 0
-      ? [siteMetadata.socialBanner]
-      : typeof images === 'string'
-      ? [images]
-      : images
+  const defaultOg = `/api/og?title=${encodeURIComponent(title)}`
+  let imagesArr = images.length === 0 ? [defaultOg] : typeof images === 'string' ? [images] : images
 
   const featuredImages = imagesArr.map((img) => {
     return {


### PR DESCRIPTION
## Summary
- generate dynamic OGP images at `/api/og`
- use new OGP image for blog posts

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685fdbbe2dd4832e875a2544aba80cb1